### PR TITLE
ip 에러 수정

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,6 @@
 var fs = require('fs'),
     path = require('path'),
     http = require('http');
-const ip = require('ip');
-const localIpAddress = ip.address();
-
 var app = require('connect')();
 var swaggerTools = require('swagger-tools');
 var jsyaml = require('js-yaml');
@@ -16,9 +13,10 @@ const envMap = {
   'prd': './config/.env',
   'dev': './config/.env.dev'
 };
-
 dotenv.config({path: envMap[process.env.NODE_ENV || 'dev']});
 console.log(`ENV: ${process.env.NODE_ENV}`)
+
+const localIpAddress = process.env.SERVER_IP || 'localhost';
 
 const { verifyTokenMiddleware } = require('./middleware/auth.js');
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "chai": "^4.2.0",
     "connect": "^3.2.0",
     "dotenv": "^8.2.0",
-    "ip": "^1.1.5",
     "js-yaml": "^3.3.0",
     "jsonwebtoken": "^8.5.1",
     "promise-mysql": "^4.1.3",


### PR DESCRIPTION
EC2 Server 에서 local IP를 조회하더라도 탄력적 IP를 가져올 수 없기 때문에
config파일에서 SERVER IP를 가져온다.