### PR TITLE
Ingredient find API 수정

### DIFF
--- a/controllers/Ingredient.js
+++ b/controllers/Ingredient.js
@@ -3,14 +3,11 @@
 const Ingredient = require('../service/IngredientService');
 const { OK } = require('../utils/statusCode.js');
 
+const { IngredientConditionDTO } = require('../data/dto');
+
 module.exports.postIngredient = (req, res, next) => {
-    const {
-        name,
-        englishName,
-        description,
-        imageUrl,
-        seriesIdx,
-    } = req.swagger.params['body'].value;
+    const { name, englishName, description, imageUrl, seriesIdx } =
+        req.swagger.params['body'].value;
     Ingredient.postIngredient({
         name,
         englishName,
@@ -67,9 +64,8 @@ module.exports.searchIngredient = (req, res, next) => {
 
 module.exports.putIngredient = (req, res, next) => {
     const ingredientIdx = req.swagger.params['ingredientIdx'].value;
-    const { name, englishName, description, imageUrl } = req.swagger.params[
-        'body'
-    ].value;
+    const { name, englishName, description, imageUrl } =
+        req.swagger.params['body'].value;
     Ingredient.putIngredient({
         ingredientIdx,
         name,
@@ -110,8 +106,7 @@ module.exports.deleteIngredient = (req, res, next) => {
 };
 
 module.exports.getIngredientByEnglishName = (req, res, next) => {
-    const { englishName } = req.body;
-    Ingredient.findIngredientByEnglishName(englishName)
+    Ingredient.findIngredient(new IngredientConditionDTO(req.body))
         .then((response) => {
             res.status(OK).json({
                 message: '재료 조회 성공',

--- a/dao/IngredientDao.js
+++ b/dao/IngredientDao.js
@@ -222,12 +222,8 @@ module.exports.readByPerfumeIdx = async (perfumeIdx) => {
  * @returns {Promise<Ingredient>}
  */
 module.exports.findIngredient = (condition) => {
-    const { ...json } = condition;
     return Ingredient.findOne({
-        where: json,
-        attributes: {
-            exclude: ['createdAt', 'updatedAt'],
-        },
+        where: { ...condition },
         raw: true,
         nest: true,
     }).then((it) => {

--- a/dao/IngredientDao.js
+++ b/dao/IngredientDao.js
@@ -222,11 +222,14 @@ module.exports.readByPerfumeIdx = async (perfumeIdx) => {
  * @returns {Promise<Ingredient>}
  */
 module.exports.findIngredient = (condition) => {
+    const { ...json } = condition;
     return Ingredient.findOne({
-        where: condition,
+        where: json,
         attributes: {
             exclude: ['createdAt', 'updatedAt'],
         },
+        raw: true,
+        nest: true,
     }).then((it) => {
         if (!it) {
             throw new NotMatchedError();

--- a/data/dto/IngredientConditionDTO.js
+++ b/data/dto/IngredientConditionDTO.js
@@ -1,0 +1,33 @@
+'use strict';
+
+class IngredientConditionDTO {
+    constructor({
+        ingredientIdx,
+        name,
+        englishName,
+        description,
+        imageUrl,
+        seriesIdx,
+    }) {
+        if (ingredientIdx) {
+            this.ingredientIdx = ingredientIdx;
+        }
+        if (name) {
+            this.name = name;
+        }
+        if (englishName) {
+            this.englishName = englishName;
+        }
+        if (description) {
+            this.description = description;
+        }
+        if (imageUrl) {
+            this.imageUrl = imageUrl;
+        }
+        if (seriesIdx) {
+            this.seriesIdx = seriesIdx;
+        }
+    }
+}
+
+module.exports = IngredientConditionDTO;

--- a/service/IngredientService.js
+++ b/service/IngredientService.js
@@ -114,11 +114,11 @@ exports.getSeriesList = (ingredientIdx) => {
 };
 
 /**
- * 재료 영어 이름으로 조회
+ * 재료 검색
  *
- * @param {string} englishName
+ * @param {IngredientConditionDTO} ingredientConditionDTO
  * @returns {Promise<Ingredient>}
  **/
-exports.findIngredientByEnglishName = (englishName) => {
-    return ingredientDao.findIngredient({ englishName });
+exports.findIngredient = (ingredientConditionDTO) => {
+    return ingredientDao.findIngredient(ingredientConditionDTO);
 };

--- a/test/dao/IngredientDao.spec.js
+++ b/test/dao/IngredientDao.spec.js
@@ -11,6 +11,8 @@ const {
 } = require('../../utils/errors/errors.js');
 const { Ingredient } = require('../../models');
 
+const { IngredientConditionDTO } = require('../../data/dto');
+
 describe('# ingredientDao Test', () => {
     before(async function () {
         await require('./common/presets.js')(this);
@@ -159,8 +161,23 @@ describe('# ingredientDao Test', () => {
 
         it('# findIngredient success case', (done) => {
             ingredientDao
+                .findIngredient(
+                    new IngredientConditionDTO({
+                        name: '재료2',
+                    })
+                )
+                .then((result) => {
+                    expect(result.name).eq('재료2');
+                    expect(result.ingredientIdx).eq(2);
+                    done();
+                })
+                .catch((err) => done(err));
+        });
+
+        it('# findIngredient success case', (done) => {
+            ingredientDao
                 .findIngredient({
-                    name: '재료1',
+                    englishName: 'ingredient english-name',
                 })
                 .then((result) => {
                     expect(result.name).eq('재료1');
@@ -169,6 +186,7 @@ describe('# ingredientDao Test', () => {
                 })
                 .catch((err) => done(err));
         });
+
         it('# findIngredient not found case', (done) => {
             ingredientDao
                 .findIngredient({


### PR DESCRIPTION
### 크롤링을 위한 API 중 오류가 있어서 수정한 PR 올립니다.

### 발생 현상
api에서 englihName 으로만 검색 가능

### 조치
api에서 다른 값으로도 검색 가능하도록 수정

변경 사항은 아래와 같습니다.

1. IngredientConditionDTO 추가
기존 IngredientDTO를 사용하면 undefined 값까지 같이 검색되어서 의도하지 않은 검색 결과가 나옴.

2. 테스트 코드 추가
ES6 class로 넘기는 테스트 코드 추가
ES6 class를 바로 Sequelizer where조건에 넣어주면 정상적으로 작동 안하는 현상 확인.
이에 ES6 class를 plain Json Object로 변경하는 코드 추가

3. Controller 수정

