### PR TITLE
Freature/issue 149 remove like cnt

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -73,9 +73,7 @@ paths:
         in: query
         type: string
         enum:
-        - likeCnt_asc
         - createdAt_asc
-        - likeCnt_desc
         - createdAt_desc
         required: false
       - name: pagingSize

--- a/dao/LikePerfumeDao.js
+++ b/dao/LikePerfumeDao.js
@@ -2,7 +2,7 @@ const {
     NotMatchedError,
     DuplicatedEntryError,
 } = require('../utils/errors/errors.js');
-const { Perfume, LikePerfume, Sequelize, sequelize } = require('../models');
+const { LikePerfume, Sequelize, sequelize } = require('../models');
 const { Op } = Sequelize;
 
 /**
@@ -13,36 +13,11 @@ const { Op } = Sequelize;
  * @returns {Promise}
  */
 module.exports.create = (userIdx, perfumeIdx) => {
-    return sequelize.transaction((t) => {
-        const createLikePerfume = LikePerfume.create(
-            { userIdx, perfumeIdx },
-            { transaction: t }
-        ).catch((err) => {
-            if (
-                err.parent.errno === 1062 ||
-                err.parent.code === 'ER_DUP_ENTRY'
-            ) {
-                throw new DuplicatedEntryError();
-            }
-            throw err;
-        });
-        const updateLikeCntOfPerfume = Perfume.findOne({
-            where: { perfumeIdx },
-        }).then((perfume) => {
-            return Perfume.update(
-                { likeCnt: perfume.likeCnt + 1 },
-                {
-                    where: { perfumeIdx: perfume.perfumeIdx },
-                    transaction: t,
-                    silent: true,
-                }
-            );
-        });
-        return Promise.all([createLikePerfume, updateLikeCntOfPerfume]).then(
-            (it) => {
-                return it[0];
-            }
-        );
+    return LikePerfume.create({ userIdx, perfumeIdx }).catch((err) => {
+        if (err.parent.errno === 1062 || err.parent.code === 'ER_DUP_ENTRY') {
+            throw new DuplicatedEntryError();
+        }
+        throw err;
     });
 };
 
@@ -72,39 +47,13 @@ module.exports.read = (userIdx, perfumeIdx) => {
  * @returns {Promise}
  */
 module.exports.delete = (userIdx, perfumeIdx) => {
-    return sequelize.transaction((t) => {
-        const deleteLikePerfume = LikePerfume.destroy({
-            where: { userIdx, perfumeIdx },
-            raw: true,
-            nest: true,
-            transaction: t,
-        }).then((it) => {
-            if (it == 0) throw new NotMatchedError();
-            return it;
-        });
-        const updateLikeCntOfPerfume = Perfume.findOne({
-            where: { perfumeIdx },
-            raw: true,
-            nest: true,
-            transaction: t,
-        }).then((perfume) => {
-            if (perfume == null) {
-                throw new NotMatchedError();
-            }
-            return Perfume.update(
-                { likeCnt: perfume.likeCnt - 1 },
-                {
-                    where: { perfumeIdx: perfume.perfumeIdx },
-                    transaction: t,
-                    silent: true,
-                }
-            );
-        });
-        return Promise.all([deleteLikePerfume, updateLikeCntOfPerfume]).then(
-            (it) => {
-                return it[0];
-            }
-        );
+    return LikePerfume.destroy({
+        where: { userIdx, perfumeIdx },
+        raw: true,
+        nest: true,
+    }).then((it) => {
+        if (it == 0) throw new NotMatchedError();
+        return it;
     });
 };
 

--- a/dao/PerfumeDao.js
+++ b/dao/PerfumeDao.js
@@ -21,7 +21,7 @@ const { ranking } = require('../mongoose_models');
 const SQL_RECOMMEND_PERFUME_BY_AGE_AND_GENDER_SELECT =
     'SELECT ' +
     'COUNT(*) AS "SearchHistory.weight", ' +
-    'p.perfume_idx AS perfumeIdx, p.brand_idx AS brandIdx, p.name, p.english_name AS englishName, p.image_url AS imageUrl, p.created_at AS createdAt, p.updated_at AS updatedAt, p.like_cnt AS likeCnt, ' +
+    'p.perfume_idx AS perfumeIdx, p.brand_idx AS brandIdx, p.name, p.english_name AS englishName, p.image_url AS imageUrl, p.created_at AS createdAt, p.updated_at AS updatedAt, ' +
     'b.brand_idx AS "Brand.brandIdx", ' +
     'b.name AS "Brand.name", ' +
     'b.english_name AS "Brand.englishName", ' +
@@ -38,7 +38,7 @@ const SQL_RECOMMEND_PERFUME_BY_AGE_AND_GENDER_SELECT =
 
 const SQL_SEARCH_PERFUME_SELECT =
     'SELECT ' +
-    'p.perfume_idx AS perfumeIdx, p.brand_idx AS brandIdx, p.name, p.english_name AS englishName, p.image_url AS imageUrl, p.created_at AS createdAt, p.updated_at AS updatedAt, p.like_cnt AS likeCnt, ' +
+    'p.perfume_idx AS perfumeIdx, p.brand_idx AS brandIdx, p.name, p.english_name AS englishName, p.image_url AS imageUrl, p.created_at AS createdAt, p.updated_at AS updatedAt, ' +
     'b.brand_idx AS "Brand.brandIdx", ' +
     'b.name AS "Brand.name", ' +
     'b.english_name AS "Brand.englishName", ' +

--- a/dao/PerfumeDao.js
+++ b/dao/PerfumeDao.js
@@ -409,7 +409,8 @@ module.exports.recommendPerfumeByAgeAndGender = async (
         count: Math.min(pagingSize, perfumeList.length),
         rows: perfumeList,
     };
-    ranking.upsert( // mongo DB 응답이 없는 경우 무한 대기하는 현상 방지를 위해 await 제거
+    ranking.upsert(
+        // mongo DB 응답이 없는 경우 무한 대기하는 현상 방지를 위해 await 제거
         { gender, ageGroup },
         { title: '나이 및 성별에 따른 추천', result }
     );

--- a/models/perfume.js
+++ b/models/perfume.js
@@ -45,11 +45,6 @@ module.exports = (sequelize, DataTypes) => {
                 type: DataTypes.STRING,
                 allowNull: false,
             },
-            likeCnt: {
-                type: DataTypes.INTEGER,
-                allowNull: false,
-                defaultValue: 0,
-            },
         },
         {
             modelName: 'Perfume',

--- a/service/PerfumeService.js
+++ b/service/PerfumeService.js
@@ -69,7 +69,6 @@ const commonJob = [
         'perfume_idx',
         'englishName',
         'brandIdx',
-        'likeCnt',
         'createdAt',
         'updatedAt'
     ),

--- a/test/dao/LikePerfumeDao.spec.js
+++ b/test/dao/LikePerfumeDao.spec.js
@@ -80,7 +80,6 @@ describe('# likePerfumeDao Test', () => {
             likePerfumeDao
                 .read(-1, 1)
                 .then((result) => {
-                    console.log(result);
                     done(new UnExpectedError(NotMatchedError));
                 })
                 .catch((err) => {

--- a/test/dao/PerfumeDao.spec.js
+++ b/test/dao/PerfumeDao.spec.js
@@ -293,27 +293,6 @@ describe('# perfumeDao Test', () => {
                     .catch((err) => done(err));
             });
 
-            it('# success case (order by like) ', (done) => {
-                perfumeDao
-                    .search([], [], [], '', 1, 100, [['likeCnt', 'asc']])
-                    .then((result) => {
-                        expect(result.count).to.be.gte(3);
-                        expect(result.rows.length).to.be.gte(3);
-                        const sortedByDao = result.rows
-                            .map((it) => it.perfumeIdx)
-                            .join(',');
-                        const sortedByJS = result.rows
-                            .sort((a, b) => {
-                                return a.likeCnt - b.likeCnt;
-                            })
-                            .map((it) => it.perfumeIdx)
-                            .join(',');
-                        expect(sortedByJS).eq(sortedByDao);
-                        done();
-                    })
-                    .catch((err) => done(err));
-            });
-
             it('# success case (order by recent)', (done) => {
                 perfumeDao
                     .search([], [], [], '', 1, 100, [['createdAt', 'desc']])

--- a/test/dao/PerfumeDao.spec.js
+++ b/test/dao/PerfumeDao.spec.js
@@ -114,7 +114,6 @@ describe('# perfumeDao Test', () => {
                         expect(result.name).to.be.eq('향수1');
                         expect(result.englishName).to.be.ok;
                         expect(result.imageUrl).to.be.ok;
-                        expect(result.likeCnt).to.be.gte(0);
 
                         expect(result.Brand.brandIdx).to.be.eq(result.brandIdx);
                         expect(result.Brand.name).to.be.eq('브랜드1');
@@ -157,7 +156,6 @@ describe('# perfumeDao Test', () => {
                             expect(perfume.imageUrl).to.be.ok;
                             expect(perfume.createdAt).to.be.not.undefined;
                             expect(perfume.updatedAt).to.be.not.undefined;
-                            expect(perfume.likeCnt).to.be.gte(0);
 
                             expect(perfume.Brand.brandIdx).to.be.oneOf(brands);
                             expect(perfume.Brand.name).to.be.ok;
@@ -224,7 +222,6 @@ describe('# perfumeDao Test', () => {
                             expect(perfume.imageUrl).to.be.ok;
                             expect(perfume.createdAt).to.be.not.undefined;
                             expect(perfume.updatedAt).to.be.not.undefined;
-                            expect(perfume.likeCnt).to.be.gte(0);
 
                             expect(perfume.Brand.brandIdx).to.be.ok;
                             expect(perfume.Brand.name).to.be.ok;
@@ -395,9 +392,6 @@ describe('# perfumeDao Test', () => {
                     .then((result) => {
                         expect(result.count).to.be.gte(3);
                         expect(result.rows.length).to.be.gte(3);
-                        for (const perfume of result.rows) {
-                            expect(perfume.likeCnt).to.be.gt(0);
-                        }
                         done();
                     })
                     .catch((err) => done(err));
@@ -441,7 +435,6 @@ describe('# perfumeDao Test', () => {
                             expect(perfume.imageUrl).to.be.ok;
                             expect(perfume.createdAt).to.be.not.undefined;
                             expect(perfume.updatedAt).to.be.not.undefined;
-                            expect(perfume.likeCnt).to.be.gte(0);
 
                             expect(perfume.Brand.brandIdx).to.be.ok;
                             expect(perfume.Brand.name).to.be.ok;
@@ -472,7 +465,6 @@ describe('# perfumeDao Test', () => {
                             expect(perfume.imageUrl).to.be.ok;
                             expect(perfume.createdAt).to.be.not.undefined;
                             expect(perfume.updatedAt).to.be.not.undefined;
-                            expect(perfume.likeCnt).to.be.gte(0);
 
                             expect(perfume.Brand.brandIdx).to.be.ok;
                             expect(perfume.Brand.name).to.be.ok;

--- a/test/dao/ReviewDao.spec.js
+++ b/test/dao/ReviewDao.spec.js
@@ -81,7 +81,6 @@ describe('# reviewDao Test', () => {
                     expect(result.Perfume.name).to.be.ok;
                     expect(result.Perfume.englishName).to.be.ok;
                     expect(result.Perfume.imageUrl).to.be.ok;
-                    expect(result.Perfume.likeCnt).to.be.ok;
                     expect(result.Perfume.brandIdx).to.be.ok;
                     expect(result.Perfume.createdAt).to.be.ok;
                     expect(result.Perfume.updatedAt).to.be.ok;
@@ -127,7 +126,6 @@ describe('# reviewDao Test', () => {
                         expect(review.Perfume.name).to.be.ok;
                         expect(review.Perfume.englishName).to.be.ok;
                         expect(review.Perfume.imageUrl).to.be.ok;
-                        expect(review.Perfume.likeCnt).to.be.ok;
                         expect(review.Perfume.brandIdx).to.be.ok;
                         expect(review.Perfume.createdAt).to.be.ok;
                         expect(review.Perfume.updatedAt).to.be.ok;

--- a/test/dao/common/seeds.js
+++ b/test/dao/common/seeds.js
@@ -70,7 +70,6 @@ module.exports = () => {
                 name: `향수${i}`,
                 englishName: `perfume-${i}`,
                 imageUrl: `http://perfume-image/${i}`,
-                likeCnt: 1,
             })
         );
     }


### PR DESCRIPTION
기획 명세상 LikePerfume은 좋아요의 역할이 아닌 위시리스트에 역할을 수행하고 있습니다.
따라서 LikeCnt 관련 로직은 필요가 없으며, 이를 삭제하였습니다.

추가로 DB에서 Perfume Table에서 LikeCnt 칼럼도 삭제를 진행하였으며
Merge하면서 dev-DV 에도 반영하겠습니다.

#149