### PR TITLE
ts-node 전역으로 설치하도록 변경

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,8 +25,8 @@ jobs:
       uses: actions/setup-node@v2
     - run: npm install -g mocha
     - run: npm install -g typescript
+    - run: npm install -g ts-node
     - run: npm install
-    - run: npm link ts-node
     - run: npm audit fix
 #    - run: npm ci
 #    - run: npm run build --if-present

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,7 @@
         "@typescript-eslint/eslint-plugin": "^4.28.4",
         "@typescript-eslint/parser": "^4.28.4",
         "eslint": "^7.31.0",
-        "supertest": "^6.1.6",
-        "ts-node": "^10.4.0"
+        "supertest": "^6.1.6"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "eslint": "^7.31.0",
-    "supertest": "^6.1.6",
-    "ts-node": "^10.4.0"
+    "supertest": "^6.1.6"
   }
 }

--- a/script/prebuild.sh
+++ b/script/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+npm install -g mocha
+npm install -g typescript
+npm install -g ts-node

--- a/script/reload.sh
+++ b/script/reload.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-npm install;
+npm install
+prebuild.sh
+
 npm audit fix;
 # npm test;
 pm2 restart ecosystem.json;


### PR DESCRIPTION
`npm link ts-node` 하는 것보다 `npm install -g ts-node`가 맞는거 같아서 수정했습니다.

추가로 전역 설치해야하는 모듈들을 prebuild.sh 스크립트에 정의했습니다.