### PR TITLE
log 출력 위치 env로 부터 주입 되도록 수정

### DIFF
--- a/src/modules/winston.ts
+++ b/src/modules/winston.ts
@@ -3,10 +3,10 @@ import winstonDaily from 'winston-daily-rotate-file';
 
 import properties from '@properties';
 
-const errorDir: string = 'logs/error';
-const logDir: string = 'logs/info';
-const httpDir: string = 'logs/http';
-const debugDir: string = 'logs/debug';
+const errorDir: string = `${properties.LOG_PATH}/error`;
+const logDir: string = `${properties.LOG_PATH}/info`;
+const httpDir: string = `${properties.LOG_PATH}/http`;
+const debugDir: string = `${properties.LOG_PATH}/debug`;
 const { combine, timestamp, printf, colorize, simple } = winston.format;
 
 const logFormat: winston.Logform.Format = printf(

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -14,6 +14,7 @@ const NULLABLE_ENV_MAP: { [key: string]: any } = {
     CORS_ALLOW_LIST: '',
     SERVER_IP: 'localhost',
     PORT: '8080',
+    LOG_PATH: 'logs',
 };
 
 type Properties = {
@@ -44,6 +45,7 @@ type Properties = {
     NODE_ENV: string;
     CORS_ALLOW_LIST: string;
     SERVER_IP: string;
+    LOG_PATH: string;
 };
 const properties: { [key: string]: any } = {};
 


### PR DESCRIPTION
서버 배포할 때 마다 log파일이 삭제되고 있어서 log 저장 위치를 env로 받도록 수정한다.
log 위치 정보는 ecosystem.json내부에 LOG_PATH로 정의한다.