### PR TITLE
개인 맞춤 추천 방어 코드 추가

### DIFF
--- a/src/controllers/Perfume.ts
+++ b/src/controllers/Perfume.ts
@@ -439,7 +439,18 @@ const recommendPersonalPerfume: RequestHandler = (
     const pagingDTO: PagingDTO = pagingRequestDTO.toPageDTO();
     return (
         loginUserIdx > 0
-            ? Perfume.recommendByUser(loginUserIdx, pagingDTO)
+            ? Perfume.recommendByUser(loginUserIdx, pagingDTO).then(
+                  (it: ListAndCountDTO<PerfumeThumbKeywordDTO>) => {
+                      // recommendByUser 는 pagingDTO를 만족해서 반환해줘야 하는데,,아닌경우가 존재함..? 재현은 안되서 방어 코드 추가
+                      if (it.rows.length <= pagingDTO.limit) {
+                          return it;
+                      }
+                      return new ListAndCountDTO<PerfumeThumbKeywordDTO>(
+                          it.count,
+                          it.rows.slice(0, pagingDTO.limit)
+                      );
+                  }
+              )
             : Perfume.getPerfumesByRandom(pagingDTO.limit)
     )
         .then((result: ListAndCountDTO<PerfumeThumbKeywordDTO>) => {


### PR DESCRIPTION
- PerfumeService:recommendByUser 에서 pagingDTO의 limit보다 큰 경우가 반환 되는 것으로 보이나 재현에 실패함.
  동일한 production-2 브랜치를 로컬에서 prd db와 연결하였으나 재현 안됨. 오로지 aws 서버에서만 재현되고 있어서 정확한 원인 파악 못함.
- 현재 기능은 임시 기능이기 때문에 정확한 원인을 파악하는 것이 아니기 때문에 방어 코드만 추가 했습니다.