### PR TITLE
[Fix] 위시리스트 향수 클릭시 작성한 시향노트 있으면 연결하게끔 코드 수정

### DIFF
--- a/src/controllers/Perfume.ts
+++ b/src/controllers/Perfume.ts
@@ -27,6 +27,7 @@ import {
     PerfumeDetailResponse,
     PerfumeResponse,
     PerfumeRecommendResponse,
+    PerfumeWishedResponse
 } from '@response/perfume';
 
 import { PagingRequestDTO } from '@request/index';
@@ -36,6 +37,7 @@ import {
     ListAndCountDTO,
     PerfumeSearchResultDTO,
     PerfumeThumbDTO,
+    PerfumeThumbWithReviewDTO,
     PerfumeThumbKeywordDTO,
     PerfumeSearchDTO,
     PagingDTO,
@@ -862,16 +864,16 @@ const getLikedPerfume: RequestHandler = (
         return;
     }
     Perfume.getLikedPerfume(userIdx, pagingRequestDTO.toPageDTO())
-        .then((result: ListAndCountDTO<PerfumeThumbDTO>) => {
-            return result.convertType(PerfumeResponse.createByJson);
+        .then((result: ListAndCountDTO<PerfumeThumbWithReviewDTO>) => {
+            return result.convertType(PerfumeWishedResponse.createByJson);
         })
-        .then((response: ListAndCountDTO<PerfumeResponse>) => {
+        .then((response: ListAndCountDTO<PerfumeWishedResponse>) => {
             LoggerHelper.logTruncated(
                 logger.debug,
                 `${LOG_TAG} getLikedPerfume's result = ${response}`
             );
             res.status(StatusCode.OK).json(
-                new ResponseDTO<ListAndCountDTO<PerfumeResponse>>(
+                new ResponseDTO<ListAndCountDTO<PerfumeWishedResponse>>(
                     MSG_GET_LIKED_PERFUME_LIST_SUCCESS,
                     response
                 )

--- a/src/controllers/Perfume.ts
+++ b/src/controllers/Perfume.ts
@@ -837,7 +837,7 @@ const getNewPerfume: RequestHandler = (
  *                 type: array
  *                 items:
  *                   allOf:
- *                   - $ref: '#/definitions/PerfumeResponse'
+ *                   - $ref: '#/definitions/PerfumeWishedResponse'
  *         default:
  *           description: successful operation
  *       x-swagger-router-controller: Perfume

--- a/src/controllers/definitions/response/perfume.ts
+++ b/src/controllers/definitions/response/perfume.ts
@@ -365,4 +365,43 @@ class PerfumeRecommendResponse extends PerfumeResponse {
     }
 }
 
-export { PerfumeDetailResponse, PerfumeResponse, PerfumeRecommendResponse };
+class PerfumeWishedResponse {
+    readonly perfumeIdx: number;
+    readonly name: string;
+    readonly brandName: string;
+    readonly imageUrl: string;
+    readonly isLiked: boolean;
+    readonly reviewIdx: number;
+    constructor(
+        perfumeIdx: number,
+        name: string,
+        brandName: string,
+        imageUrl: string,
+        isLiked: boolean,
+        reviewIdx: number
+    ) {
+        this.perfumeIdx = perfumeIdx;
+        this.name = name;
+        this.brandName = brandName;
+        this.imageUrl = imageUrl;
+        this.isLiked = isLiked;
+        this.reviewIdx = reviewIdx;
+    }
+
+    public toString(): string {
+        return `${this.constructor.name} (${JSON.stringify(this)})`;
+    }
+
+    static createByJson(json: any): PerfumeWishedResponse {
+        return new PerfumeWishedResponse(
+            json.perfumeIdx,
+            json.name,
+            json.brandName,
+            json.imageUrl,
+            json.isLiked,
+            json.reviewIdx
+        );
+    }
+}
+
+export { PerfumeDetailResponse, PerfumeResponse, PerfumeRecommendResponse, PerfumeWishedResponse };

--- a/src/controllers/definitions/response/perfume.ts
+++ b/src/controllers/definitions/response/perfume.ts
@@ -364,7 +364,32 @@ class PerfumeRecommendResponse extends PerfumeResponse {
         );
     }
 }
-
+/**
+ * @swagger
+ * definitions:
+ *   PerfumeWishedResponse:
+ *     type: object
+ *     properties:
+ *       perfumeIdx:
+ *         type: number
+ *       name:
+ *         type: string
+ *       brandName:
+ *         type: string
+ *       imageUrl:
+ *         type: string
+ *       isLiked:
+ *         type: boolean
+ *       reviewIdx:
+ *         trype: number
+ *     example:
+ *       perfumeIdx: 1
+ *       name: 154 코롱
+ *       brandName: 154 kolon
+ *       imageUrl: https://contents.lotteon.com/itemimage/_v065423/LE/12/04/59/50/19/_1/22/48/08/13/9/LE1204595019_1224808139_1.jpg/dims/resizef/554X554
+ *       isLiked: true
+ *       reviewIdx: 1
+ * */
 class PerfumeWishedResponse {
     readonly perfumeIdx: number;
     readonly name: string;

--- a/src/dao/ReviewDao.ts
+++ b/src/dao/ReviewDao.ts
@@ -274,6 +274,31 @@ class ReviewDao {
             nest: true,
         });
     };
+
+    /**
+     * 향수 리스트에 관해, 내가 작성한 시향노트 조회
+     *
+     * @param {number[]} userIdx
+     * @param {number[]} perfumeIdxList
+     * @returns {Promise}
+     */
+     async readAllMineOfPerfumes(
+        userIdx: number,
+        perfumeIdxList: number[]
+    ): Promise<{ userIdx: number; perfumeIdx: number }[]> {
+        return Review.findAll({
+            where: {
+                userIdx,
+                perfumeIdx: {
+                    [Op.in]: perfumeIdxList,
+                },
+            },
+            raw: true,
+            nest: true,
+        }).then((res: any[]) => {
+            return res
+        });
+    }
 }
 
 export default ReviewDao;

--- a/src/dao/ReviewDao.ts
+++ b/src/dao/ReviewDao.ts
@@ -282,10 +282,10 @@ class ReviewDao {
      * @param {number[]} perfumeIdxList
      * @returns {Promise}
      */
-     async readAllMineOfPerfumes(
+    readAllMineOfPerfumes(
         userIdx: number,
         perfumeIdxList: number[]
-    ): Promise<{ userIdx: number; perfumeIdx: number }[]> {
+    ): Promise<any> {
         return Review.findAll({
             where: {
                 userIdx,
@@ -295,9 +295,7 @@ class ReviewDao {
             },
             raw: true,
             nest: true,
-        }).then((res: any[]) => {
-            return res
-        });
+        })
     }
 }
 

--- a/src/data/dto/PerfumeThumbWithReviewDTO.ts
+++ b/src/data/dto/PerfumeThumbWithReviewDTO.ts
@@ -1,0 +1,52 @@
+import { BrandDTO } from '@dto/BrandDTO';
+
+class PerfumeThumbWithReviewDTO {
+    readonly perfumeIdx: number;
+    readonly name: string;
+    readonly brandName: string;
+    readonly isLiked: boolean;
+    readonly imageUrl: string;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+    readonly Brand: BrandDTO;
+    readonly reviewIdx: number;
+    constructor(
+        perfumeIdx: number,
+        name: string,
+        isLiked: boolean,
+        imageUrl: string,
+        createdAt: Date,
+        updatedAt: Date,
+        Brand: BrandDTO,
+        reviewIdx: number
+    ) {
+        this.perfumeIdx = perfumeIdx;
+        this.name = name;
+        this.brandName = Brand.name;
+        this.isLiked = isLiked || false;
+        this.imageUrl = imageUrl;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.Brand = Brand;
+        this.reviewIdx = reviewIdx;
+    }
+
+    public toString(): string {
+        return `${this.constructor.name} (${JSON.stringify(this)})`;
+    }
+
+    static createByJson(json: any): PerfumeThumbWithReviewDTO {
+        return new PerfumeThumbWithReviewDTO(
+            json.perfumeIdx,
+            json.name,
+            json.isLiked,
+            json.imageUrl,
+            json.createdAt,
+            json.updatedAt,
+            json.Brand,
+            json.reviewIdx
+        );
+    }
+}
+
+export { PerfumeThumbWithReviewDTO };

--- a/src/data/dto/index.ts
+++ b/src/data/dto/index.ts
@@ -16,6 +16,7 @@ export * from './PerfumeInquireHistoryDTO';
 export * from './PerfumeSearchResultDTO';
 export * from './PerfumeSummaryDTO';
 export * from './PerfumeThumbDTO';
+export * from './PerfumeThumbWithReviewDTO';
 export * from './PerfumeThumbKeywordDTO';
 export * from './InquireHistoryDTO';
 export * from './ReportUserInquirePerfumeDTO';

--- a/src/service/PerfumeService.ts
+++ b/src/service/PerfumeService.ts
@@ -398,8 +398,9 @@ class PerfumeService {
                 );
                 const likePerfumeList: any[] =
                     await likePerfumeDao.readLikeInfo(userIdx, perfumeIdxList);
-                const perfumeReivewList: any[] =
+                const perfumeReivewList: any[] = 
                     await reviewDao.readAllMineOfPerfumes(userIdx, perfumeIdxList);
+                console.log('perfumeReivewList', perfumeReivewList)
                 return result.convertType((item: any) => {
                     return fp.compose(
                         ...commonJob,

--- a/test/service/PerfumeService.spec.ts
+++ b/test/service/PerfumeService.spec.ts
@@ -18,6 +18,7 @@ import {
     PerfumeSearchDTO,
     PerfumeThumbDTO,
     PerfumeThumbKeywordDTO,
+    PerfumeThumbWithReviewDTO
 } from '@dto/index';
 
 import PerfumeIntegralMockHelper from '../mock_helper/PerfumeIntegralMockHelper';
@@ -84,6 +85,26 @@ describe('# Perfume Service Test', () => {
                                 accessTime: '2021-09-26T08:38:33.000Z',
                             },
                             LikeReview: { likeCount: 1 },
+                        },
+                    ];
+                };
+                mockReviewDao.readAllMineOfPerfumes = async () => {
+                    return [
+                        {
+                            id: 1,
+                            score: 1,
+                            longevity: 1,
+                            sillage: 1,
+                            seasonal: 4,
+                            gender: 1,
+                            access: 1,
+                            content: '시향노트1',
+                            likeCnt: 0,
+                            createdAt: '2021-09-26T08:38:33.000Z',
+                            updatedAt: '2022-06-01T11:09:46.000Z',
+                            deletedAt: null,
+                            perfumeIdx: 1,
+                            userIdx: 1
                         },
                     ];
                 };
@@ -296,8 +317,17 @@ describe('# Perfume Service Test', () => {
                     perfumeIdx,
                 }));
             };
+            mockReviewDao.readAllMineOfPerfumes = async (
+                _: number,
+                perfumeIdxList: number[]
+            ) => {
+                return perfumeIdxList.map((perfumeIdx: number) => ({
+                    reviewIdx: 0,
+                    perfumeIdx,
+                }));
+            };
             Perfume.getLikedPerfume(1, defaultPagingDTO)
-                .then((result: ListAndCountDTO<PerfumeThumbDTO>) => {
+                .then((result: ListAndCountDTO<PerfumeThumbWithReviewDTO>) => {
                     expect(result).to.be.instanceOf(ListAndCountDTO);
                     result.rows.forEach((item) => {
                         expect(item.isLiked).to.be.true;


### PR DESCRIPTION
위시리스트(유저가 좋아하는 향수 목록) 조회 API Response에 reviewIdx를 추가하도록 코드 수정했습니다.

- PerfumeThumbWithReviewDTO 생성
- PerfumeService Class수정
  - perfumeIdx 목록에 reviewIdx 매칭해주는 matchReviewsWithPerfumesJob() 생성
  - getLikedPerfume() 수정
- PerfumeResponse에 PerfumeWishedResponse 클래스 생성
- Perfume Service Test 코드 수정
- ReviewDao에 readAllMineOfPerfumes() 생성

Closes #378 