### PR TITLE
향수 추천(일반) 에서 로그인 정보 사용하도록 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "a-fume-server",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-fume-server",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "향수 정보 서비스 A.fume Server Api 문서",
   "main": "index.js",
   "type": "commonjs",

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -107,7 +107,7 @@ const MSG_GET_SUPPORTABLE_NO: string =
 
 const NO_AUTHORIZE: string = '권한이 없습니다.';
 
-const CURRENT_VERSION: string = process.env.npm_package_version || '0.0.3';
+const CURRENT_VERSION: string = process.env.npm_package_version || '0.0.4';
 /* TODO BASE PATH 는 MAJOR만 따르도록 수정할 것. 0.0.1 -> 1.0 -> 2.0 */
 const BASE_PATH: string = '/A.fume/api/0.0.1';
 


### PR DESCRIPTION
- 향수 추천(일반) 에서 로그인 하였는데 성별 정보를 request에 보내주지 않는 경우는 login 토큰으로 부터 성별 정보를 가져오도록 수정