### PR TITLE
Modify app.ts to parse large JSON format body data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@types/swagger-ui-express": "^4.1.3",
                 "@types/winston": "^2.4.4",
                 "aws-sdk": "^2.1101.0",
+                "body-parser": "^1.20.1",
                 "chai": "^4.3.6",
                 "connect": "^3.7.0",
                 "cookie-parser": "^1.4.6",
@@ -2819,9 +2820,9 @@
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         },
         "node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
@@ -2831,7 +2832,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "raw-body": "2.5.1",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -2853,6 +2854,20 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/body-parser/node_modules/qs": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "dependencies": {
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -4138,6 +4153,29 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/express/node_modules/body-parser": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.10.3",
+                "raw-body": "2.5.1",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
             }
         },
         "node_modules/express/node_modules/cookie": {
@@ -10151,9 +10189,9 @@
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         },
         "body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
             "requires": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
@@ -10163,7 +10201,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
+                "qs": "6.11.0",
                 "raw-body": "2.5.1",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -10181,6 +10219,14 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                },
+                "qs": {
+                    "version": "6.11.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+                    "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
                 }
             }
         },
@@ -11170,6 +11216,25 @@
                 "vary": "~1.1.2"
             },
             "dependencies": {
+                "body-parser": {
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+                    "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+                    "requires": {
+                        "bytes": "3.1.2",
+                        "content-type": "~1.0.4",
+                        "debug": "2.6.9",
+                        "depd": "2.0.0",
+                        "destroy": "1.2.0",
+                        "http-errors": "2.0.0",
+                        "iconv-lite": "0.4.24",
+                        "on-finished": "2.4.1",
+                        "qs": "6.10.3",
+                        "raw-body": "2.5.1",
+                        "type-is": "~1.6.18",
+                        "unpipe": "1.0.0"
+                    }
+                },
                 "cookie": {
                     "version": "0.5.0",
                     "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@types/swagger-ui-express": "^4.1.3",
         "@types/winston": "^2.4.4",
         "aws-sdk": "^2.1101.0",
+        "body-parser": "^1.20.1",
         "chai": "^4.3.6",
         "connect": "^3.7.0",
         "cookie-parser": "^1.4.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ dotenv.config();
 import cookieParser from 'cookie-parser';
 import cors, { CorsOptions, CorsOptionsDelegate } from 'cors';
 import express, { Express } from 'express';
+const bodyParser = require('body-parser');
 import createError from 'http-errors';
 
 import properties from '@properties';
@@ -48,7 +49,7 @@ const corsOptionsDelegate: CorsOptionsDelegate<express.Request> = function (
 };
 
 app.use(cors(corsOptionsDelegate));
-app.use(express.json());
+app.use(bodyParser.json({ limit: "5mb"}));
 
 app.use(
     makeMorgan((message: string) => {


### PR DESCRIPTION
### Why
Closes #429 

### What's being changed:
- JSON format body data의 size limit을 변경하기 위해, [body-parser](https://www.npmjs.com/package/body-parser) npm module 이 추가되었습니다.
- body-parser를 사용해 JSON format body data를 파싱합니다.
-  JSON format body data의 size limit을 100Kb(default) -> 5Mb 로 변경했습니다.
(데이터 팀으로부터 샘플 추천 데이터를 받았을때 약 835Mb 인 점을 참고했습니다.)