### PR TITLE
Update deploy-development.yml

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -30,7 +30,7 @@ jobs:
         cache-dependency-path: ${{ env.NODE_ENV }}/package-lock.json
     - run: cp ~/config-injection/ecosystem-${{ env.NODE_ENV }}.json ${{ env.PROJECT_PATH }}/ecosystem.json
     - run: cp ~/config-injection/.env ${{ env.PROJECT_PATH }}/.env
-    - run: sudo ${{ env.PROJECT_PATH }}/script/prebuild.sh
+#     - run: sudo ${{ env.PROJECT_PATH }}/script/prebuild.sh
     - run: ${{ env.PROJECT_PATH }}/script/reload.sh
     env:
       NODE_ENV: development


### PR DESCRIPTION
### Why:
Issue #433 

### What's being changed:
prebuild.sh 파일을 run 하는 부분에 병목이 발생해서 서버에 과부하가 발생합니다.
해당 작업 없이 배포했을때 정상 동작한다면, 해당 부분은 독립적으로 분리하는것이 좋을 것 같습니다.

I'm gonna disable running pre-build tasks because of the bottlenack.