### PR TITLE
Bug/issue 435 nodejs 12 actions are deprecated

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     defaults:
       run:


### PR DESCRIPTION
### Why:
Closes #435 

### What's being changed:

GitHub Actions [Deploy development server to ec2](https://github.com/A-fume/A.fume.Server/actions/workflows/deploy-development.yml) job 의 `use Node.js 12` step에서 병목이 생기다가 fail이 발생했는데,
Node.js 12 를 더 이상 사용할 수 없게 된것이 원인인 것 같아 버전 16으로 Upgrade 진행 했습니다.

Upgrade version of Node.js 12 to 16