### PR TITLE
Bug/issue 435 nodejs 12 actions are deprecated

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -19,11 +19,11 @@ jobs:
       run:
         working-directory: ${{ env.NODE_ENV }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
       with:
         path: ${{ env.NODE_ENV }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 #v.3.5.1
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     defaults:
       run:


### PR DESCRIPTION
### Why:
Closes #435 

### What's being changed:

Node.js 12가 deprecated 됨에 따라, 엮여있는 다른 action들의 버전도 함께 업데이트 시켜주었습니다.

```
 Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2
```
업데이트 버전은 [해당 discussion](https://github.com/electron/forge/pull/2966)을 참고했습니다.


Update some versions as node.js 12 is deprecated

<img width="1151" alt="스크린샷 2022-12-21 오후 12 29 50" src="https://user-images.githubusercontent.com/35447878/208816410-cff7927c-68c3-4797-bad0-3e33e2d2941e.png">
