### PR TITLE
[Fix] Replace incorrectly declared variable name with correct variable name

### DIFF
--- a/tests/test_integral/auth.spec.ts
+++ b/tests/test_integral/auth.spec.ts
@@ -11,7 +11,7 @@ import app from '@src/app';
 import { TokenSetDTO } from '@dto/index';
 import { BASE_PATH, ABNORMAL_CONNECTION } from '@utils/strings';
 
-import { ResponseDTO, SimpleResponseDTO, Opcode } from '@response/common';
+import { ResponseDTO, SimpleResponseDTO, OpCode } from '@response/common';
 import { LoginResponse } from '@response/user';
 
 const basePath: string = BASE_PATH;
@@ -122,7 +122,7 @@ describe('# Auth Controller Test', () => {
                                                 responseDTO.message
                                             ).to.be.eq(ABNORMAL_CONNECTION);
                                             expect(responseDTO.opcode).to.be.eq(
-                                                Opcode.LOGOUT
+                                                OpCode.LOGOUT
                                             );
                                             done();
                                         }


### PR DESCRIPTION
### Why?
Closes #444 
### What's being changed:
Fixed TSError since replacing `Opcode`  with `OpCode`.

<img width="1181" alt="스크린샷 2023-01-03 오후 1 14 51" src="https://user-images.githubusercontent.com/35447878/210300203-d442d861-4b9c-41ce-b6bb-4e9f53d63232.png">
