### PR TITLE
Feat/issue 482 personal recommended perfume have 3 or more reviews

### DIFF
--- a/src/controllers/Perfume.ts
+++ b/src/controllers/Perfume.ts
@@ -520,7 +520,7 @@ const recommendPersonalPerfume: RequestHandler = (
                       );
                   }
               )
-            : Perfume.getPerfumesByRandom(pagingDTO.limit)
+            : Perfume.getPerfumesByRandom(pagingDTO.limit, 3)
     )
         .then((result: ListAndCountDTO<PerfumeThumbKeywordDTO>) => {
             return supplementPerfumeWithRandom(result, pagingDTO.limit);

--- a/src/dao/PerfumeDao.ts
+++ b/src/dao/PerfumeDao.ts
@@ -606,7 +606,7 @@ class PerfumeDao {
                 )
             )
         )
-        return result.map(PerfumeThumbDTO.createByJson);;
+        return result.map(PerfumeThumbDTO.createByJson);
     }
 
     /**

--- a/src/dao/PerfumeDao.ts
+++ b/src/dao/PerfumeDao.ts
@@ -21,7 +21,6 @@ const {
     Brand,
     InquireHistory,
     LikePerfume,
-    Review,
     sequelize,
     Sequelize,
 } = require('@sequelize');

--- a/src/dao/PerfumeDao.ts
+++ b/src/dao/PerfumeDao.ts
@@ -587,7 +587,8 @@ class PerfumeDao {
     
     /**
      * 유효 시향기 n개 이상 보유 조건을 만족하는 랜덤 향수 조회
-     *
+     * 
+     * @todo sequelize raw query 대신 findall 사용하도록 변경하기
      * @param {number} size
      * @param {number} minReviewCount
      * @returns {Promise<PerfumeThumbDTO[]>}

--- a/src/dao/PerfumeDao.ts
+++ b/src/dao/PerfumeDao.ts
@@ -587,7 +587,6 @@ class PerfumeDao {
     /**
      * 유효 시향기 n개 이상 보유 조건을 만족하는 랜덤 향수 조회
      * 
-     * @todo sequelize raw query 대신 findall 사용하도록 변경하기
      * @param {number} size
      * @param {number} minReviewCount
      * @returns {Promise<PerfumeThumbDTO[]>}

--- a/src/service/PerfumeService.ts
+++ b/src/service/PerfumeService.ts
@@ -479,28 +479,32 @@ class PerfumeService {
 
     /**
      * 랜덤 향수 조회
+     * minReviewCount 지정시, 유효 시향기 n개 이상 보유 조건을 만족하는 향수 조회
      *
      * @param {number} size
-     * @returns {Promise<PerfumeThumbKeywordDTO[]>}
+     * @param {number} minReviewCount
+     * @returns {Promise<ListAndCountDTO<PerfumeThumbDTO>>}
      **/
-    getPerfumesByRandom(
-        size: number
+    async getPerfumesByRandom(
+        size: number,
+        minReviewCount: number = 0
     ): Promise<ListAndCountDTO<PerfumeThumbKeywordDTO>> {
         logger.debug(`${LOG_TAG} getPerfumesByRandom(size = ${size})`);
-        return perfumeDao
-            .getPerfumesByRandom(size)
-            .then(
-                (
-                    result: [PerfumeThumbDTO]
-                ): Promise<ListAndCountDTO<PerfumeThumbKeywordDTO>> => {
-                    return this.convertToThumbKeyword(
-                        new ListAndCountDTO<PerfumeThumbDTO>(
-                            result.length,
-                            result
-                        )
-                    );
-                }
-            );
+        let result:  PerfumeThumbDTO[] | [] = [];
+        
+        if (minReviewCount == 0) {
+            result = await perfumeDao.getPerfumesByRandom(size)
+        }
+        if (minReviewCount > 0) {
+            result = await perfumeDao.getPerfumesWithMinReviewsByRandom(size, minReviewCount)
+        }
+
+        return await this.convertToThumbKeyword(
+             new ListAndCountDTO<PerfumeThumbDTO>(
+                result.length,
+                result
+            )
+        );
     }
 
     /**

--- a/src/service/PerfumeService.ts
+++ b/src/service/PerfumeService.ts
@@ -490,7 +490,7 @@ class PerfumeService {
         minReviewCount: number = 0
     ): Promise<ListAndCountDTO<PerfumeThumbKeywordDTO>> {
         logger.debug(`${LOG_TAG} getPerfumesByRandom(size = ${size})`);
-        let result:  PerfumeThumbDTO[] | [] = [];
+        let result:  PerfumeThumbDTO[] = [];
         
         if (minReviewCount == 0) {
             result = await perfumeDao.getPerfumesByRandom(size)

--- a/tests/test_unit/dao/PerfumeDao.spec.ts
+++ b/tests/test_unit/dao/PerfumeDao.spec.ts
@@ -594,9 +594,9 @@ describe('# perfumeDao Test', () => {
                     perfumeDao.getPerfumesByRandom(defaultPagingDTO.limit),
                     perfumeDao.getPerfumesByRandom(defaultPagingDTO.limit),
                 ])
-                    .then((result: [[PerfumeThumbDTO], [PerfumeThumbDTO]]) => {
-                        const result1: [PerfumeThumbDTO] = result[0];
-                        const result2: [PerfumeThumbDTO] = result[1];
+                    .then((result: [PerfumeThumbDTO[], PerfumeThumbDTO[]]) => {
+                        const result1: PerfumeThumbDTO[] = result[0];
+                        const result2: PerfumeThumbDTO[] = result[1];
                         expect(
                             _.zip(result1, result2).filter(
                                 (


### PR DESCRIPTION
### Why:
<!-- If there's an existing issue for your change, please link the issue with closing keywords. -->
Closes #482 
### What's being changed:
<!--if available, include any code snippets, screenshots, or gifs -->
Update the personal perfume recommendation feature to search for perfumes with at least `3` reviews.
- Create PerfumeDAO.getPerfumesWithMinReviewsByRandom().
- Add `minReviewCount` parameter to perfumeService.getPerfumesByRandom().
- Reflact changes in perfumeService.getPerfumesByRandom() to controllers.
