### PR TITLE
Feat/issue 482 personal recommended perfume have 3 or more reviews

### DIFF
--- a/src/controllers/Perfume.ts
+++ b/src/controllers/Perfume.ts
@@ -520,7 +520,7 @@ const recommendPersonalPerfume: RequestHandler = (
                       );
                   }
               )
-            : Perfume.getPerfumesByRandom(pagingDTO.limit)
+            : Perfume.getPerfumesByRandom(pagingDTO.limit, 3)
     )
         .then((result: ListAndCountDTO<PerfumeThumbKeywordDTO>) => {
             return supplementPerfumeWithRandom(result, pagingDTO.limit);

--- a/src/dao/PerfumeDao.ts
+++ b/src/dao/PerfumeDao.ts
@@ -87,6 +87,22 @@ const SQL_SEARCH_PERFUME_SELECT_COUNT: string =
     'INNER JOIN brands b ON p.brand_idx = b.brand_idx ' +
     'WHERE p.deleted_at IS NULL AND (:whereCondition) ';
 
+const SQL_SEARCH_RANDOM_PERFUME_WITH_MIN_REVIEW_COUNT: string = 
+    'SELECT ' +
+    '`Perfume`.perfume_idx AS perfumeIdx, `Perfume`.brand_idx AS brandIdx, `Perfume`.name, `Perfume`.english_name AS englishName, `Perfume`.image_url AS imageUrl, `Perfume`.created_at AS createdAt, `Perfume`.updated_at AS updatedAt, ' +
+    'COUNT(`Review`.`id`), ' +
+    '`Brand`.`brand_idx` AS `Brand.brandIdx`, `Brand`.`name` AS `Brand.name`, `Brand`.`english_name` AS `Brand.englishName`, `Brand`.`first_initial` AS `Brand.firstInitial`, `Brand`.`image_url` AS `Brand.imageUrl`, `Brand`.`description` AS `Brand.description`, `Brand`.`created_at` AS `Brand.createdAt`, `Brand`.`updated_at` AS `Brand.updatedAt`, `Brand`.`deleted_at` AS `Brand.deletedAt` ' +
+    'FROM `perfumes` AS `Perfume` ' +
+    'INNER JOIN `brands` AS `Brand` ' +
+    'ON `Perfume`.`brand_idx` = `Brand`.`brand_idx` ' +
+    'INNER JOIN `reviews` As `Review` ' +
+    'ON `Perfume`.`perfume_idx` = `Review`.`perfume_idx` ' +
+    'WHERE (`Brand`.`deleted_at` IS NULL) AND (`Perfume`.`deleted_at` IS NULL) AND (`Review`.`deleted_at` IS NULL) AND (`Review`.`access` = 1) ' +
+    'GROUP BY `Perfume`.`perfume_idx` ' +
+    'HAVING COUNT(`Review`.`id`) >= :minReviewCount ' +
+    'ORDER BY rand() ' +
+    'LIMIT :size '
+
 const defaultOption: { [key: string]: any } = {
     include: [
         {
@@ -554,9 +570,9 @@ class PerfumeDao {
      * 랜덤 향수 조회
      *
      * @param {number} size
-     * @returns {Promise<Perfume[]>}
+     * @returns {Promise<PerfumeThumbDTO[]>}
      */
-    async getPerfumesByRandom(size: number): Promise<[PerfumeThumbDTO]> {
+    async getPerfumesByRandom(size: number): Promise< PerfumeThumbDTO[]> {
         logger.debug(`${LOG_TAG} getPerfumesByRandom(size = ${size})`);
         const options: { [key: string]: any } = _.merge({}, defaultOption, {
             order: Sequelize.literal('rand()'),
@@ -565,6 +581,31 @@ class PerfumeDao {
         return Perfume.findAll(options).then((rows: any[]) => {
             return rows.map(PerfumeThumbDTO.createByJson);
         });
+    }
+
+    
+    /**
+     * 유효 시향기 n개 이상 보유 조건을 만족하는 랜덤 향수 조회
+     * 
+     * @param {number} size
+     * @param {number} minReviewCount
+     * @returns {Promise<PerfumeThumbDTO[]>}
+     */
+    async getPerfumesWithMinReviewsByRandom(size: number, minReviewCount: number): Promise<PerfumeThumbDTO[]> {
+        logger.debug(`${LOG_TAG} getPerfumesWithMinReviewsByRandom(size = ${size}, minReviewCount = ${minReviewCount})`);
+        const result: PerfumeThumbDTO[] = (
+            await sequelize.query(
+                SQL_SEARCH_RANDOM_PERFUME_WITH_MIN_REVIEW_COUNT, Object.assign(
+                    {
+                        replacements: {minReviewCount: minReviewCount, size: size},
+                        type: sequelize.QueryTypes.SELECT,
+                        raw: true,
+                        nest: true
+                    }
+                )
+            )
+        )
+        return result.map(PerfumeThumbDTO.createByJson);
     }
 
     /**

--- a/src/service/PerfumeService.ts
+++ b/src/service/PerfumeService.ts
@@ -479,28 +479,32 @@ class PerfumeService {
 
     /**
      * 랜덤 향수 조회
+     * minReviewCount 지정시, 유효 시향기 n개 이상 보유 조건을 만족하는 향수 조회
      *
      * @param {number} size
-     * @returns {Promise<PerfumeThumbKeywordDTO[]>}
+     * @param {number} minReviewCount
+     * @returns {Promise<ListAndCountDTO<PerfumeThumbDTO>>}
      **/
-    getPerfumesByRandom(
-        size: number
+    async getPerfumesByRandom(
+        size: number,
+        minReviewCount: number = 0
     ): Promise<ListAndCountDTO<PerfumeThumbKeywordDTO>> {
         logger.debug(`${LOG_TAG} getPerfumesByRandom(size = ${size})`);
-        return perfumeDao
-            .getPerfumesByRandom(size)
-            .then(
-                (
-                    result: [PerfumeThumbDTO]
-                ): Promise<ListAndCountDTO<PerfumeThumbKeywordDTO>> => {
-                    return this.convertToThumbKeyword(
-                        new ListAndCountDTO<PerfumeThumbDTO>(
-                            result.length,
-                            result
-                        )
-                    );
-                }
-            );
+        let result:  PerfumeThumbDTO[] = [];
+        
+        if (minReviewCount == 0) {
+            result = await perfumeDao.getPerfumesByRandom(size)
+        }
+        if (minReviewCount > 0) {
+            result = await perfumeDao.getPerfumesWithMinReviewsByRandom(size, minReviewCount)
+        }
+
+        return await this.convertToThumbKeyword(
+             new ListAndCountDTO<PerfumeThumbDTO>(
+                result.length,
+                result
+            )
+        );
     }
 
     /**

--- a/tests/test_unit/dao/PerfumeDao.spec.ts
+++ b/tests/test_unit/dao/PerfumeDao.spec.ts
@@ -594,9 +594,9 @@ describe('# perfumeDao Test', () => {
                     perfumeDao.getPerfumesByRandom(defaultPagingDTO.limit),
                     perfumeDao.getPerfumesByRandom(defaultPagingDTO.limit),
                 ])
-                    .then((result: [[PerfumeThumbDTO], [PerfumeThumbDTO]]) => {
-                        const result1: [PerfumeThumbDTO] = result[0];
-                        const result2: [PerfumeThumbDTO] = result[1];
+                    .then((result: [PerfumeThumbDTO[], PerfumeThumbDTO[]]) => {
+                        const result1: PerfumeThumbDTO[] = result[0];
+                        const result2: PerfumeThumbDTO[] = result[1];
                         expect(
                             _.zip(result1, result2).filter(
                                 (


### PR DESCRIPTION
### Why:
<!-- If there's an existing issue for your change, please link the issue with closing keywords. -->
Closes #482
### What's being changed:
<!--if available, include any code snippets, screenshots, or gifs -->
- Update the personal perfume recommendation feature to search for perfumes with at least 3 reviews.
  - Create PerfumeDAO.getPerfumesWithMinReviewsByRandom().
  - Add minReviewCount parameter to perfumeService.getPerfumesByRandom().
  - Reflact changes in perfumeService.getPerfumesByRandom() to controllers.